### PR TITLE
Fixed Solaris 10 setup keystrokes

### DIFF
--- a/solaris10.json
+++ b/solaris10.json
@@ -104,6 +104,7 @@
         "<f2><wait>",
         "<f2><wait>",
         "<f2><wait>",
+        "<f2><wait>",
         "<wait10><wait10><wait10><wait10><wait10><wait10>",
         "<wait10><wait10><wait10><wait10><wait10><wait10>",
         "<wait10><wait10><wait10><wait10><wait10><wait10>",


### PR DESCRIPTION
Added missing F2 (before installation is started). Otherwise, the installation was stalled at the review stage.
