### PR TITLE
Add headless option

### DIFF
--- a/solaris10.json
+++ b/solaris10.json
@@ -1,6 +1,7 @@
 {
   "builders": [
     {
+      "headless": true,
       "boot_command": [
         "<enter><wait10><wait10><wait10>",
         "4",


### PR DESCRIPTION
I had to add this headless option to run packer without a GUI running on my build machine. Do you think this would be a sane default since it will work in either case and people can turn it off if they want to display the GUI? 

Here's the error I got without it: 

[ernie@eaharch1 solaris-packer[master*]]$ packer build --only=virtualbox-iso solaris10.json
virtualbox-iso output will be in this color.

==> virtualbox-iso: Downloading or copying Guest additions
    virtualbox-iso: Downloading or copying: file:///usr/lib/virtualbox/additions/VBoxGuestAdditions.iso
==> virtualbox-iso: Downloading or copying ISO
    virtualbox-iso: Downloading or copying: file:///home/ernie/sol-10-u11-ga-x86-dvd.iso
==> virtualbox-iso: Creating virtual machine...
==> virtualbox-iso: Creating hard drive...
==> virtualbox-iso: Creating forwarded port mapping for SSH (host port 3027)
==> virtualbox-iso: Executing custom VBoxManage commands...
    virtualbox-iso: Executing: modifyvm packer-solaris-10 --memory 1536
    virtualbox-iso: Executing: modifyvm packer-solaris-10 --cpus 1
==> virtualbox-iso: Starting the virtual machine...
==> virtualbox-iso: Error starting VM: VBoxManage error:
==> virtualbox-iso: Unregistering and deleting virtual machine...
==> virtualbox-iso: Deleting output directory...
Build 'virtualbox-iso' errored: Error starting VM: VBoxManage error:

==> Some builds didn't complete successfully and had errors:
--> virtualbox-iso: Error starting VM: VBoxManage error:

==> Builds finished but no artifacts were created.
[ernie@eaharch1 solaris-packer[master*]]$
